### PR TITLE
Move shared azure resources from dqt api repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+.DEFAULT_GOAL		:=help
+SHELL				:=/bin/bash
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z\.\-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: dev
+dev:
+	$(eval DEPLOY_ENV=dev)
+	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-development)
+	$(eval SERVICE_PRINCIPAL_NAME=s165d01-keyvault-readonly-access)
+	$(eval RESOURCE_GROUP_NAME=s165d01-rg)
+
+.PHONY: test
+test:
+	$(eval DEPLOY_ENV=test)
+	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-test)
+	$(eval SERVICE_PRINCIPAL_NAME=s165t01-keyvault-readonly-access)
+	$(eval RESOURCE_GROUP_NAME=s165t01-rg)
+
+.PHONY: pre-production
+pre-production:
+	$(eval DEPLOY_ENV=pre-production)
+	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-test)
+	$(eval SERVICE_PRINCIPAL_NAME=s165t01-preprod-keyvault-readonly-access)
+	$(eval RESOURCE_GROUP_NAME=s165t01-preprod-rg)
+
+.PHONY: production
+production:
+	$(eval DEPLOY_ENV=production)
+	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-production)
+	$(eval SERVICE_PRINCIPAL_NAME=s165p01-keyvault-readonly-access)
+	$(eval RESOURCE_GROUP_NAME=s165p01-rg)
+
+deploy-azure-resources: ## make dev deploy-azure-resources CONFIRM_DEPLOY=1
+	$(if $(CONFIRM_DEPLOY), , $(error can only run with CONFIRM_DEPLOY))
+	pwsh ./azure/Set-ResourceGroup.ps1 -ResourceGroupName ${RESOURCE_GROUP_NAME} -Subscription ${AZURE_SUBSCRIPTION} -EnvironmentName ${DEPLOY_ENV} -ParametersFile "./azure/azuredeploy.${DEPLOY_ENV}.parameters.json" -ServicePrincipalName ${SERVICE_PRINCIPAL_NAME}

--- a/azure/Set-ResourceGroup.ps1
+++ b/azure/Set-ResourceGroup.ps1
@@ -1,0 +1,45 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [String]$ResourceGroupName,
+    [Parameter(Mandatory = $true)]
+    [String]$EnvironmentName,
+    [Parameter(Mandatory = $true)]
+    [String]$Subscription,
+    [Parameter(Mandatory = $true)]
+    [String]$ParametersFile,
+    [Parameter(Mandatory = $true)]
+    [String]$ServicePrincipalName
+)
+
+$ErrorActionPreference = "Stop"
+
+$parentBusiness = "Teacher Training and Qualifications"
+$portfolio = "Early Years and Schools Group"
+$product = "Database of Qualified Teachers"
+$service = "Teacher Training and Qualifications"
+$serviceLine = "Teaching Workforce"
+$serviceOffering = "Database of Qualified Teachers"
+
+& az account set --subscription $Subscription
+
+$spId = (& az ad sp list --display-name $ServicePrincipalName | ConvertFrom-Json).objectId
+
+if ($null -eq $spId) {
+    Write-Error "Cannot find service principal named: '$ServicePrincipalName'."
+}
+
+$rgExists = & az group exists --name $ResourceGroupName
+
+if ($rgExists -ne "true") {
+    & az group create `
+        --location "West Europe" `
+        --name $ResourceGroupName `
+        --tags "Environment=${EnvironmentName}" "Parent Business=${parentBusiness}" "Portfolio=${portfolio}" "Product=${product}" "Service=${service}" "Service Line=${serviceLine}" "Service Offering=${serviceOffering}"
+}
+
+& az deployment group create `
+    --resource-group $ResourceGroupName `
+    --template-file (Join-Path $PSScriptRoot "azuredeploy.json") `
+    --parameters "@${ParametersFile}" `
+    --parameters "keyVaultReaderServicePrincipalId=${spId}"

--- a/azure/azuredeploy.dev.parameters.json
+++ b/azure/azuredeploy.dev.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "keyVaultName": {
+      "value": "s165d01-kv"
+    },
+    "tfStateStorageAccountName": {
+      "value": "s165d01tfstate"
+    }
+  }
+}

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "keyVaultName": {
+      "type": "string"
+    },
+    "tfStateStorageAccountName": {
+      "type": "string"
+    },
+    "dbBackupStorageAccountName": {
+      "type": "string",
+      "defaultValue": "false"
+    },
+    "keyVaultReaderServicePrincipalId": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "tenantId": "9c7d9dd3-840c-4b3f-818e-552865082e16",
+    "deliveryTeamGroupId": "ce5793a4-b822-4018-a65d-6c04e96918b2",
+    "tfStateContainers": ["dqtapi-tfstate", "dqtmonitoring-tfstate", "fmtrn-tfstate"],
+    "dbBackupContainers": ["find-a-lost-trn", "dqt-api"]
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-06-01",
+      "name": "[parameters('tfStateStorageAccountName')]",
+      "location": "[variables('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "IsVersioningEnabled": true
+      }
+    },
+    {
+      "condition": "[not(equals(parameters('dbBackupStorageAccountName'), 'false'))]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-06-01",
+      "name": "[parameters('dbBackupStorageAccountName')]",
+      "location": "[variables('location')]",
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "IsVersioningEnabled": true
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2019-06-01",
+      "name": "[concat(parameters('tfStateStorageAccountName'), '/default/', variables('tfStateContainers')[copyIndex()])]",
+      "copy": {
+        "name": "blobIterator",
+        "count": "[length(variables('tfStateContainers'))]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('tfStateStorageAccountName'))]"
+      ]
+    },
+    {
+      "condition": "[not(equals(parameters('dbBackupStorageAccountName'), 'false'))]",
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2019-06-01",
+      "name": "[concat(parameters('dbBackupStorageAccountName'), '/default/', variables('dbBackupContainers')[copyIndex()])]",
+      "copy": {
+        "name": "blobIterator",
+        "count": "[length(variables('dbBackupContainers'))]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('dbBackupStorageAccountName'))]"
+      ]
+    },
+    {
+      "condition": "[not(equals(parameters('dbBackupStorageAccountName'), 'false'))]",
+      "name": "[concat(parameters('dbBackupStorageAccountName'), '/default')]",
+      "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+      "apiVersion": "2019-06-01",
+      "dependsOn": [
+          "[concat('Microsoft.Storage/storageAccounts/', parameters('dbBackupStorageAccountName'))]"
+      ],
+      "properties": {
+          "policy": {
+              "rules": [
+                  {
+                      "name": "ruleDelete",
+                      "enabled": true,
+                      "type": "Lifecycle",
+                      "definition": {
+                          "filters": {
+                              "blobTypes": [
+                                  "blockBlob"
+                              ],
+                              "prefixMatch": [
+                                  "find-a-lost-trn",
+                                  "dqt-api"
+                              ]
+                          },
+                          "actions": {
+                              "baseBlob": {
+                                  "delete": {
+                                      "daysAfterModificationGreaterThan": 35
+                                  }
+                              },
+                              "snapshot": {
+                                  "delete": {
+                                      "daysAfterCreationGreaterThan": 35
+                                  }
+                              }
+                          }
+                      }
+                  }
+              ]
+          }
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "[parameters('keyVaultName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "accessPolicies": [
+          {
+            "tenantId": "[variables('tenantId')]",
+            "objectId": "[variables('deliveryTeamGroupId')]",
+            "permissions": {
+              "secrets": [
+                "get",
+                "list",
+                "set",
+                "delete",
+                "recover",
+                "backup",
+                "restore"
+              ]
+            }
+          },
+          {
+            "tenantId": "[variables('tenantId')]",
+            "objectId": "[parameters('keyVaultReaderServicePrincipalId')]",
+            "permissions": {
+              "secrets": [
+                "get",
+                "list"
+              ]
+            }
+          }
+        ],
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "tenantId": "[variables('tenantId')]"
+      }
+    }
+  ]
+}

--- a/azure/azuredeploy.pre-production.parameters.json
+++ b/azure/azuredeploy.pre-production.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "keyVaultName": {
+      "value": "s165t01-preprod-kv"
+    },
+    "tfStateStorageAccountName": {
+      "value": "s165t01preprodtfstate"
+    }
+  }
+}

--- a/azure/azuredeploy.production.parameters.json
+++ b/azure/azuredeploy.production.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "keyVaultName": {
+      "value": "s165p01-kv"
+    },
+    "tfStateStorageAccountName": {
+      "value": "s165p01tfstate"
+    },
+    "dbBackupStorageAccountName": {
+      "value": "s165p01dbbackup"
+    }
+  }
+}

--- a/azure/azuredeploy.test.parameters.json
+++ b/azure/azuredeploy.test.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "keyVaultName": {
+      "value": "s165t01-kv"
+    },
+    "tfStateStorageAccountName": {
+      "value": "s165t01tfstate"
+    }
+  }
+}


### PR DESCRIPTION
### Context

Shared Azure resources such as storage accounts and keyvaults used by TRA projects should be deployed from a shared repository. This PR moves the script and ARM templates used to deploy Azure resources.

### Trello card

https://trello.com/c/HksO8ReX