### PR TITLE
Add a container to Terraform state storage

### DIFF
--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -20,7 +20,7 @@
     "location": "[resourceGroup().location]",
     "tenantId": "9c7d9dd3-840c-4b3f-818e-552865082e16",
     "deliveryTeamGroupId": "ce5793a4-b822-4018-a65d-6c04e96918b2",
-    "tfStateContainers": ["dqtapi-tfstate", "dqtmonitoring-tfstate", "fmtrn-tfstate"],
+    "tfStateContainers": ["dqtapi-tfstate", "dqtmonitoring-tfstate", "fmtrn-tfstate", "dqt-scripts-tfstate"],
     "dbBackupContainers": ["find-a-lost-trn", "dqt-api"]
   },
   "resources": [


### PR DESCRIPTION
### Context

DQT service needs a storage account deployment used to store scripts.
This storage account deployment files will be stored in tra-crm-automation
repo. The terraform state file will live in the current storages for
other TRA deployments.