### PR TITLE
Add a container to terraform state storage and db backup.

### DIFF
--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -20,8 +20,8 @@
     "location": "[resourceGroup().location]",
     "tenantId": "9c7d9dd3-840c-4b3f-818e-552865082e16",
     "deliveryTeamGroupId": "ce5793a4-b822-4018-a65d-6c04e96918b2",
-    "tfStateContainers": ["dqtapi-tfstate", "dqtmonitoring-tfstate", "fmtrn-tfstate", "dqt-scripts-tfstate"],
-    "dbBackupContainers": ["find-a-lost-trn", "dqt-api"]
+    "tfStateContainers": ["dqtapi-tfstate", "dqtmonitoring-tfstate", "fmtrn-tfstate", "dqt-scripts-tfstate", "apply-qts-tfstate"],
+    "dbBackupContainers": ["find-a-lost-trn", "dqt-api", "apply-qts"]
   },
   "resources": [
     {


### PR DESCRIPTION
**Context**
Apply for QTS needs a storage container for storing terraform state and another container for storing db backups.

[x] [Attach to trello](https://trello.com/c/bTnbGHeC/460-update-deployment-arm-template-in-tra-shared-services)