### PR TITLE
Add custom domain for Apply for QTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 
 .PHONY: pre-production
 pre-production:
-	$(eval DEPLOY_ENV=pre-production)
+	$(eval DEPLOY_ENV=preprod)
 	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-test)
 	$(eval SERVICE_PRINCIPAL_NAME=s165t01-preprod-keyvault-readonly-access)
 	$(eval RESOURCE_GROUP_NAME=s165t01-preprod-rg)
@@ -58,7 +58,7 @@ domains-infra-apply: domains-infra-init
 domains-init: set-production-subscription set-azure-account
 	terraform -chdir=custom_domains/${DOMAINS_ID} init -upgrade -reconfigure -backend-config=workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}_backend.tfvars
 
-domains-plan: domains-init
+domains-plan: domains-init  #make apply-for-qts pre-production domains-plan
 	terraform -chdir=custom_domains/${DOMAINS_ID} plan -var-file workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}.tfvars.json
 
 domains-apply: domains-init

--- a/custom_domains/afqts/.terraform.lock.hcl
+++ b/custom_domains/afqts/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.10.0"
   hashes = [
     "h1:3We9b8sM4m5kmGKc2wrQkoXoL9wsEEjZvAbpM87Dil8=",
+    "h1:pa+WRfGci/bQBLpuL/QOX91iu1vSf5gPsHmYzH/a+EE=",
     "zh:01f749bc6f5fde7ef1dcdf741d32fe05cb3e6b3b550659981c7aaff6ee47a55e",
     "zh:1d6525872c6cf2c2437b3dfff34b285fd00cb2b8d55d9b0686738887fbdae6ea",
     "zh:3c1a9fa26d3e455275ddfc2b72e8173cdb83ae75500eb0e8dd6f080e26d1b177",

--- a/custom_domains/afqts/main.tf
+++ b/custom_domains/afqts/main.tf
@@ -12,8 +12,8 @@ data "azurerm_cdn_frontdoor_profile" "main" {
   resource_group_name = var.resource_group_name
 }
 
-resource "azurerm_cdn_frontdoor_rule_set" "example" {
-  name                     = "redirectwww"
+resource "azurerm_cdn_frontdoor_rule_set" "ruleset" {
+  name                     = var.ruleset_name
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
 }
 

--- a/custom_domains/afqts/variables.tf
+++ b/custom_domains/afqts/variables.tf
@@ -3,6 +3,7 @@ variable "front_door_name" {}
 variable "resource_group_name" {}
 variable "domains" {}
 variable "environment_tag" {}
+variable "ruleset_name" {}
 
 locals {
   default_tags = {

--- a/custom_domains/afqts/workspace_variables/afqts_dev.tfvars.json
+++ b/custom_domains/afqts/workspace_variables/afqts_dev.tfvars.json
@@ -2,7 +2,7 @@
     "zone": "apply-for-qts-in-england.education.gov.uk",
     "front_door_name": "s165p01-afqtsdomains-fd",
     "resource_group_name": "s165p01-afqtsdomains-rg",
-    "domains": ["www", "apex"],
-    "environment_tag" : "Prod",
-    "ruleset_name": "redirectwww"
+    "domains": ["dev"],
+    "environment_tag" : "dev",
+    "ruleset_name": "dev"
 }

--- a/custom_domains/afqts/workspace_variables/afqts_dev_backend.tfvars
+++ b/custom_domains/afqts/workspace_variables/afqts_dev_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s165p01-afqtsdomains-rg"
+storage_account_name = "s165p01afqtsdomainstf"
+container_name       = "afqtsdomains-tf"
+key                  = "afqtsdomains_dev.tfstate"

--- a/custom_domains/afqts/workspace_variables/afqts_preprod.tfvars.json
+++ b/custom_domains/afqts/workspace_variables/afqts_preprod.tfvars.json
@@ -2,7 +2,7 @@
     "zone": "apply-for-qts-in-england.education.gov.uk",
     "front_door_name": "s165p01-afqtsdomains-fd",
     "resource_group_name": "s165p01-afqtsdomains-rg",
-    "domains": ["www", "apex"],
-    "environment_tag" : "Prod",
-    "ruleset_name": "redirectwww"
+    "domains": ["preprod"],
+    "environment_tag" : "pre-prod",
+    "ruleset_name": "preprod"
 }

--- a/custom_domains/afqts/workspace_variables/afqts_preprod_backend.tfvars
+++ b/custom_domains/afqts/workspace_variables/afqts_preprod_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s165p01-afqtsdomains-rg"
+storage_account_name = "s165p01afqtsdomainstf"
+container_name       = "afqtsdomains-tf"
+key                  = "afqtsdomains_preprod.tfstate"

--- a/custom_domains/afqts/workspace_variables/afqts_test.tfvars.json
+++ b/custom_domains/afqts/workspace_variables/afqts_test.tfvars.json
@@ -2,7 +2,7 @@
     "zone": "apply-for-qts-in-england.education.gov.uk",
     "front_door_name": "s165p01-afqtsdomains-fd",
     "resource_group_name": "s165p01-afqtsdomains-rg",
-    "domains": ["www", "apex"],
-    "environment_tag" : "Prod",
-    "ruleset_name": "redirectwww"
+    "domains": ["test"],
+    "environment_tag" : "test",
+    "ruleset_name": "test"
 }

--- a/custom_domains/afqts/workspace_variables/afqts_test_backend.tfvars
+++ b/custom_domains/afqts/workspace_variables/afqts_test_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s165p01-afqtsdomains-rg"
+storage_account_name = "s165p01afqtsdomainstf"
+container_name       = "afqtsdomains-tf"
+key                  = "afqtsdomains_test.tfstate"


### PR DESCRIPTION
Custom domain deployment for Apply for QTS requires terraform deployment of Azure front door components. This PR adds the files necessary for terraform and modification to Makefile to support the deployment