### PR TITLE
Remove afqts resource creation from old ARM templates.

### DIFF
--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -20,8 +20,8 @@
     "location": "[resourceGroup().location]",
     "tenantId": "9c7d9dd3-840c-4b3f-818e-552865082e16",
     "deliveryTeamGroupId": "ce5793a4-b822-4018-a65d-6c04e96918b2",
-    "tfStateContainers": ["dqtapi-tfstate", "dqtmonitoring-tfstate", "fmtrn-tfstate", "dqt-scripts-tfstate", "apply-qts-tfstate"],
-    "dbBackupContainers": ["find-a-lost-trn", "dqt-api", "apply-qts"]
+    "tfStateContainers": ["dqtapi-tfstate", "dqtmonitoring-tfstate", "fmtrn-tfstate", "dqt-scripts-tfstate"],
+    "dbBackupContainers": ["find-a-lost-trn", "dqt-api"]
   },
   "resources": [
     {


### PR DESCRIPTION
Since apply for QTS resources gets created using new ARM templates (resourcedeploy.json) these entries can be removed from old ARM templates


[x] Attached to trello