### PR TITLE
Add getanid deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ production:
 apply-for-qts:
 	$(eval DOMAINS_ID=afqts)
 
+getanid:
+	$(eval DOMAINS_ID=getanid)
+
 deploy-azure-resources: ## make dev deploy-azure-resources CONFIRM_DEPLOY=1
 	$(if $(CONFIRM_DEPLOY), , $(error can only run with CONFIRM_DEPLOY))
 	pwsh ./azure/Set-ResourceGroup.ps1 -ResourceGroupName ${RESOURCE_GROUP_NAME} -Subscription ${AZURE_SUBSCRIPTION} -EnvironmentName ${DEPLOY_ENV} -ParametersFile "./azure/azuredeploy.${DEPLOY_ENV}.parameters.json" -ServicePrincipalName ${SERVICE_PRINCIPAL_NAME}
@@ -61,5 +64,5 @@ domains-init: set-production-subscription set-azure-account
 domains-plan: domains-init  #make apply-for-qts pre-production domains-plan
 	terraform -chdir=custom_domains/${DOMAINS_ID} plan -var-file workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}.tfvars.json
 
-domains-apply: domains-init
+domains-apply: domains-init # make getanid pre-production domains-apply
 	terraform -chdir=custom_domains/${DOMAINS_ID} apply -var-file workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}.tfvars.json

--- a/custom_domains/getanid/main.tf
+++ b/custom_domains/getanid/main.tf
@@ -1,0 +1,58 @@
+module "domains" {
+  source              = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains"
+  zone                = var.zone
+  front_door_name     = var.front_door_name
+  resource_group_name = var.resource_group_name
+  domains             = var.domains
+  environment         = var.environment_short
+  host_name           = data.azurerm_linux_web_app.app.default_hostname
+
+}
+
+data "azurerm_cdn_frontdoor_profile" "main" {
+  name                = var.front_door_name
+  resource_group_name = var.resource_group_name
+}
+
+data "azurerm_linux_web_app" "app" {
+  provider            = azurerm.app_subcription
+  name                = var.app_name
+  resource_group_name = var.app_resource_group_name
+}
+
+data "azurerm_dns_zone" "main" {
+  name                = var.zone
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "ruleset" {
+  name                     = var.environment_short
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
+}
+
+resource "azurerm_cdn_frontdoor_rule" "rule" {
+  for_each = var.redirect_rules
+  depends_on = [module.domains]
+  name                      = replace(
+                                replace(each.key, ".", ""),
+                                "-", "")
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.ruleset.id
+  order                     = 1
+  behavior_on_match         = "Continue"
+
+  actions {
+
+    url_redirect_action {
+      redirect_type        = "Moved"
+      redirect_protocol    = "Https"
+      destination_hostname = each.value
+    }
+  }
+
+  conditions {
+    host_name_condition {
+      operator         = "Equal"
+      match_values     = [each.key]
+    }
+  }
+}

--- a/custom_domains/getanid/terraform.tf
+++ b/custom_domains/getanid/terraform.tf
@@ -1,0 +1,25 @@
+terraform {
+
+  required_version = "~> 1.2"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.22.0"
+    }
+  }
+  backend "azurerm" {
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+}
+
+provider "azurerm" {
+  features {}
+  version         = "3.22.0"
+  alias           = "app_subcription"
+  subscription_id = var.app_sub_id
+}

--- a/custom_domains/getanid/variables.tf
+++ b/custom_domains/getanid/variables.tf
@@ -1,0 +1,12 @@
+variable "zone" {}
+variable "front_door_name" {}
+variable "resource_group_name" {}
+variable "domains" {}
+variable "environment_short" {}
+variable "app_name" {}
+variable "app_resource_group_name" {}
+variable "app_sub_id" {}
+variable "redirect_rules" {
+  default = {}
+}
+

--- a/custom_domains/getanid/workspace_variables/getanid_dev.tfvars.json
+++ b/custom_domains/getanid/workspace_variables/getanid_dev.tfvars.json
@@ -1,0 +1,10 @@
+{
+    "zone": "teaching-identity.education.gov.uk",
+    "front_door_name": "s165p01-getaniddomains-fd",
+    "resource_group_name": "s165p01-getaniddomains-rg",
+    "domains": ["dev"],
+    "environment_short": "dev",
+    "app_name": "s165d01-getanid-dev-auths-app",
+    "app_resource_group_name": "s165d01-getanid-dv-rg",
+    "app_sub_id": "9816b7b0-58ca-4972-b25b-c7dbd3ee1c6d"
+}

--- a/custom_domains/getanid/workspace_variables/getanid_dev_backend.tfvars
+++ b/custom_domains/getanid/workspace_variables/getanid_dev_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s165p01-getaniddomains-rg"
+storage_account_name = "s165p01getaniddomainstf"
+container_name       = "getaniddomains-tf"
+key                  = "getaniddomains_dev.tfstate"

--- a/custom_domains/getanid/workspace_variables/getanid_preprod.tfvars.json
+++ b/custom_domains/getanid/workspace_variables/getanid_preprod.tfvars.json
@@ -1,0 +1,10 @@
+{
+    "zone": "teaching-identity.education.gov.uk",
+    "front_door_name": "s165p01-getaniddomains-fd",
+    "resource_group_name": "s165p01-getaniddomains-rg",
+    "domains": ["preprod"],
+    "environment_short": "preprod",
+    "app_name": "s165t01-getanid-preprod-auths-app",
+    "app_resource_group_name": "s165t01-getanid-pp-rg",
+    "app_sub_id": "250ff557-239a-4d89-83a4-07bdfc6218c7"
+}

--- a/custom_domains/getanid/workspace_variables/getanid_preprod_backend.tfvars
+++ b/custom_domains/getanid/workspace_variables/getanid_preprod_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s165p01-getaniddomains-rg"
+storage_account_name = "s165p01getaniddomainstf"
+container_name       = "getaniddomains-tf"
+key                  = "getaniddomains_preprod.tfstate"

--- a/custom_domains/getanid/workspace_variables/getanid_production.tfvars.json
+++ b/custom_domains/getanid/workspace_variables/getanid_production.tfvars.json
@@ -1,0 +1,14 @@
+{
+    "zone": "teaching-identity.education.gov.uk",
+    "front_door_name": "s165p01-getaniddomains-fd",
+    "resource_group_name": "s165p01-getaniddomains-rg",
+    "domains": ["www", "apex"],
+    "environment_short": "prod",
+    "redirect_rules": {
+        "www.teaching-identity.education.gov.uk" : "teaching-identity.education.gov.uk"
+    },
+    "app_name": "s165p01-getanid-production-auths-app",
+    "app_resource_group_name": "s165p01-getanid-pd-rg",
+    "app_sub_id": "9c2dcb72-4bba-4acc-8d5f-8b8389a68238"
+}
+

--- a/custom_domains/getanid/workspace_variables/getanid_production_backend.tfvars
+++ b/custom_domains/getanid/workspace_variables/getanid_production_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s165p01-getaniddomains-rg"
+storage_account_name = "s165p01getaniddomainstf"
+container_name       = "getaniddomains-tf"
+key                  = "getaniddomains_production.tfstate"

--- a/custom_domains/infrastructure/terraform.tf
+++ b/custom_domains/infrastructure/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.10.0"
+      version = "3.22.0"
     }
   }
   backend "azurerm" {

--- a/custom_domains/infrastructure/workspace_variables/getanid.tfvars.json
+++ b/custom_domains/infrastructure/workspace_variables/getanid.tfvars.json
@@ -1,0 +1,17 @@
+{
+    "hosted_zone": {
+        "teaching-identity.education.gov.uk": {
+            "resource_group_name": "s165p01-getaniddomains-rg",
+            "front_door_name": "s165p01-getaniddomains-fd"
+        }
+    },
+    "tags": {
+        "Parent Business": "Teacher Training and Qualifications",
+        "Portfolio": "Early Years and Schools Group",
+        "Product": "Get an Identity",
+        "Service": "Teacher Training and Qualifications",
+        "Service Line": "Teaching Workforce",
+        "Service Offering": "Get an Identity",
+        "Environment": "Prod"
+    }
+}

--- a/custom_domains/infrastructure/workspace_variables/getanid_backend.tfvars
+++ b/custom_domains/infrastructure/workspace_variables/getanid_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s165p01-getaniddomains-rg"
+storage_account_name = "s165p01getaniddomainstf"
+container_name       = "getaniddomains-tf"
+key                  = "getaniddomains.tfstate"


### PR DESCRIPTION
### Context

Get an Identity service will need a front door instance and DNS zone to configure custom domain. This commit adds the infrastructure level and environment level deployments to enable custom domain configuration.

### Trello card

https://trello.com/c/AM6y1jHr