### PR TITLE
Add missing frontdoor terraform resources

### DIFF
--- a/custom_domains/aytp/terraform.tf
+++ b/custom_domains/aytp/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.26.0"
+      version = "3.28.0"
     }
   }
   backend "azurerm" {
@@ -19,7 +19,7 @@ provider "azurerm" {
 
 provider "azurerm" {
   features {}
-  version         = "3.26.0"
+  version         = "3.28.0"
   alias           = "app_subcription"
   subscription_id = var.app_sub_id
 }

--- a/custom_domains/aytp/workspace_variables/aytp_production.tfvars.json
+++ b/custom_domains/aytp/workspace_variables/aytp_production.tfvars.json
@@ -2,7 +2,7 @@
     "zone": "access-your-teaching-profile.education.gov.uk",
     "front_door_name": "s165p01-aytpdomains-fd",
     "resource_group_name": "s165p01-aytpdomains-rg",
-    "domains": ["apex"],
+    "domains": ["apex", "www"],
     "environment_short": "prod",
     "redirect_rules": {
         "www.access-your-teaching-profile.education.gov.uk" : "access-your-teaching-profile.education.gov.uk"

--- a/custom_domains/infrastructure/terraform.tf
+++ b/custom_domains/infrastructure/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.26.0"
+      version = "3.28.0"
     }
   }
   backend "azurerm" {


### PR DESCRIPTION
Associating multiple custom domains to a single route was previously missing in the Terraform azurerm provider. The latest release of 3.28.0 fixes these bugs. This commit adds the configuration such that production custom domains can be associated to the same production route.