### PR TITLE
Adds a workflow to tag this repo on merge to main

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,19 @@
+name: Tag
+
+on:
+  push:
+    branches:
+    - main
+    paths-ignore:
+    - 'custom_domains/**'
+
+jobs:
+  tag:
+    name: Push Git Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag and Create Release
+        uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: patch
+          tag_prefix: ""


### PR DESCRIPTION
## Context

This repo contains artifacts, eg ARM templates, that are used by other upstream workflows.  Tagging the assets in this repo will allow these workflows to control which version of the assets they consume and prevent the risk of breaking changes being inadvertently introduced.

## Changes proposed in this pull request

- Adds a workflow to tag this repo on merge to main.  The semver is bumped using a label added to the GitHub PR, valid labels are `release/major`, `release/minor` and `release/patch`
  - Paths that don't include assets used upstream are excluded
  - The default increment is patch, this is applied whether or not a label is added to the PR

## Guidance to review

All steps of the workflow are triggered by a PR except pushing the tags to GitHub.  The workflow logs can be reviewed to see the changes to the tag that this PR would make.