### PR TITLE
Refactor arm templates

### DIFF
--- a/azure/resourcedeploy.json
+++ b/azure/resourcedeploy.json
@@ -14,9 +14,6 @@
     "tfStorageContainerName": {
       "type": "string"
     },
-    "environment": {
-      "type": "string"
-    },
     "dbBackupStorageAccountName": {
       "type": "string",
       "defaultValue": ""
@@ -37,80 +34,78 @@
     }
   },
   "variables": {
-    "subscriptionId": "[subscription().subscriptionId]",
+    "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/tra-shared-services/main/azure/templates/",
     "deployBackupStorage": "[and(not(empty(parameters('dbBackupStorageAccountName'))),not(empty(parameters('dbBackupStorageContainerName'))))]"
   },
   "resources": [
     {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
-      "name": "[format('create-{0}', parameters('resourceGroupName'))]",
+      "apiVersion": "2021-04-01",
+      "name": "[parameters('resourceGroupName')]",
+      "type": "Microsoft.Resources/resourceGroups",
       "location": "[parameters('location')]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "resourceGroupName": {
-            "value": "[parameters('resourceGroupName')]"
-          },
-          "environment": {
-            "value": "[parameters('environment')]"
-          },
-          "location": {
-            "value": "[parameters('location')]"
-          },
-          "tags": {
-            "value": "[parameters('tags')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "resourceGroupName": {
-              "type": "string",
-              "metadata": {
-                "description": "Name of the resourceGroup."
-              }
-            },
-            "environment": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string",
-              "defaultValue": "[parameters('location')]"
-            },
-            "tags": {
-              "type": "object",
-              "defaultValue": "[parameters('tags')]"
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Resources/resourceGroups",
-              "apiVersion": "2021-04-01",
-              "name": "[parameters('resourceGroupName')]",
-              "location": "[parameters('location')]",
-              "tags": "[parameters('tags')]",
-              "properties": {}
-            }
-          ]
-        }
-      }
+      "tags": "[parameters('tags')]",
+      "properties": {}
     },
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
-      "name": "[format('create-{0}-required-resources', parameters('resourceGroupName'))]",
-      "subscriptionId": "[variables('subscriptionId')]",
+      "name": "[format('create-{0}', parameters('tfStorageAccountName'))]",
       "resourceGroup": "[parameters('resourceGroupName')]",
       "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
         "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'storage-account.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "sku": {
+            "value": "Standard_ZRS"
+          },
+          "storageAccountName": {
+            "value": "[parameters('tfStorageAccountName')]"
+          }
+        }
+      },
+      "dependsOn": ["[parameters('resourceGroupName')]"]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('create-{0}', parameters('tfStorageContainerName'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'storage-blob-container.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "storageAccountName": {
+            "value": "[parameters('tfStorageAccountName')]"
+          },
+          "storageContainerName": {
+            "value": "[parameters('tfStorageContainerName')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[format('create-{0}', parameters('tfStorageAccountName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('create-{0}', parameters('keyVaultName'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'key-vault.json')]",
+          "contentVersion": "1.0.0.0"
+        },
         "parameters": {
           "location": {
             "value": "[parameters('location')]"
@@ -118,221 +113,87 @@
           "keyVaultName": {
             "value": "[parameters('keyVaultName')]"
           },
-          "tfStorageAccountName": {
-            "value": "[parameters('tfStorageAccountName')]"
-          },
-          "tfStorageContainerName": {
-            "value": "[parameters('tfStorageContainerName')]"
-          },
           "enabledForTemplateDeployment": {
             "value": true
           }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string"
-            },
-            "keyVaultName": {
-              "type": "string"
-            },
-            "tfStorageAccountName": {
-              "type": "string"
-            },
-            "tfStorageContainerName": {
-              "type": "string"
-            },
-            "enabledForTemplateDeployment": {
-              "type": "bool"
-            }
-          },
-          "variables": {
-            "tenantId": "[subscription().tenantId]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "apiVersion": "2021-09-01",
-              "name": "[parameters('tfStorageAccountName')]",
-              "location": "[parameters('location')]",
-              "kind": "StorageV2",
-              "properties": {
-                "minimumTlsVersion": "TLS1_2",
-                "supportsHttpsTrafficOnly": true,
-                "allowBlobPublicAccess": false
-              },
-              "sku": {
-                "name": "Standard_ZRS"
-              }
-            },
-            {
-              "type": "Microsoft.Storage/storageAccounts/blobServices",
-              "apiVersion": "2021-09-01",
-              "name": "[format('{0}/default', parameters('tfStorageAccountName'))]",
-              "properties": {
-                "containerDeleteRetentionPolicy": {
-                  "allowPermanentDelete": false,
-                  "days": 30,
-                  "enabled": true
-                },
-                "deleteRetentionPolicy": {
-                  "allowPermanentDelete": false,
-                  "days": 30,
-                  "enabled": true
-                },
-                "isVersioningEnabled": true
-              },
-
-              "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('tfStorageAccountName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-              "apiVersion": "2021-09-01",
-              "name": "[format('{0}/default/{1}', parameters('tfStorageAccountName'), parameters('tfStorageContainerName'))]",
-              "properties": {
-                "publicAccess": "None"
-              },
-
-              "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('tfStorageAccountName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.KeyVault/vaults",
-              "apiVersion": "2021-10-01",
-              "name": "[parameters('keyVaultName')]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "enableSoftDelete": true,
-                "enabledForTemplateDeployment": "[parameters('enabledForTemplateDeployment')]",
-                "enableRbacAuthorization": true,
-                "enablePurgeProtection": true,
-                "tenantId": "[variables('tenantId')]",
-                "sku": {
-                  "family": "A",
-                  "name": "standard"
-                }
-              }
-            }
-          ]
         }
       },
-      "dependsOn": [
-        "[subscriptionResourceId(variables('subscriptionId'), 'Microsoft.Resources/deployments', format('create-{0}', parameters('resourceGroupName')))]"
-      ]
+      "dependsOn": ["[parameters('resourceGroupName')]"]
     },
     {
-      "condition": "[variables('deployBackupStorage')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
-      "name": "[format('create-{0}-optional-backup-storage', parameters('resourceGroupName'))]",
-      "subscriptionId": "[variables('subscriptionId')]",
+      "name": "[format('create-{0}-account', parameters('dbBackupStorageAccountName'))]",
+      "condition": "[variables('deployBackupStorage')]",
       "resourceGroup": "[parameters('resourceGroupName')]",
       "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
         "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'storage-account.json')]",
+          "contentVersion": "1.0.0.0"
+        },
         "parameters": {
           "location": {
             "value": "[parameters('location')]"
           },
-          "dbBackupStorageAccountName": {
+          "sku": {
+            "value": "Standard_GRS"
+          },
+          "storageAccountName": {
+            "value": "[parameters('dbBackupStorageAccountName')]"
+          }
+        }
+      },
+      "dependsOn": ["[parameters('resourceGroupName')]"]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('create-{0}-container', parameters('dbBackupStorageContainerName'))]",
+      "condition": "[variables('deployBackupStorage')]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'storage-blob-container.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "storageAccountName": {
             "value": "[parameters('dbBackupStorageAccountName')]"
           },
-          "dbBackupStorageContainerName": {
+          "storageContainerName": {
             "value": "[parameters('dbBackupStorageContainerName')]"
           }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string"
-            },
-            "dbBackupStorageAccountName": {
-              "type": "string"
-            },
-            "dbBackupStorageContainerName": {
-              "type": "string"
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "apiVersion": "2019-06-01",
-              "name": "[parameters('dbBackupStorageAccountName')]",
-              "location": "[parameters('location')]",
-              "sku": {
-                "name": "Standard_GRS"
-              },
-              "kind": "StorageV2",
-              "properties": {
-                "IsVersioningEnabled": true
-              }
-            },
-            {
-              "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-              "apiVersion": "2019-06-01",
-              "name": "[concat(parameters('dbBackupStorageAccountName'), '/default/', parameters('dbBackupStorageContainerName'))]",
-              "properties": {
-                "publicAccess": "None"
-              },
-              "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('dbBackupStorageAccountName'))]"
-              ]
-            },
-            {
-              "name": "[concat(parameters('dbBackupStorageAccountName'), '/default')]",
-              "type": "Microsoft.Storage/storageAccounts/managementPolicies",
-              "apiVersion": "2019-06-01",
-              "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('dbBackupStorageAccountName'))]"
-              ],
-              "properties": {
-                "policy": {
-                  "rules": [
-                    {
-                      "name": "ruleDelete",
-                      "enabled": true,
-                      "type": "Lifecycle",
-                      "definition": {
-                        "filters": {
-                          "blobTypes": [
-                            "blockBlob"
-                          ],
-                          "prefixMatch": [
-                            "[parameters('dbBackupStorageContainerName')]"
-                          ]
-                        },
-                        "actions": {
-                          "baseBlob": {
-                            "delete": {
-                              "daysAfterModificationGreaterThan": 35
-                            }
-                          },
-                          "snapshot": {
-                            "delete": {
-                              "daysAfterCreationGreaterThan": 35
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          ]
         }
       },
       "dependsOn": [
-        "[subscriptionResourceId(variables('subscriptionId'), 'Microsoft.Resources/deployments', format('create-{0}', parameters('resourceGroupName')))]"
+        "[format('create-{0}-account', parameters('dbBackupStorageAccountName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('create-{0}-mgmt-policy', parameters('dbBackupStorageAccountName'))]",
+      "condition": "[variables('deployBackupStorage')]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'storage-management-policy.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "storageAccountName": {
+            "value": "[parameters('dbBackupStorageAccountName')]"
+          },
+          "storageContainerName": {
+            "value": "[parameters('dbBackupStorageContainerName')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[format('create-{0}-account', parameters('dbBackupStorageAccountName'))]"
       ]
     }
   ]

--- a/azure/templates/key-vault.json
+++ b/azure/templates/key-vault.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string"
+    },
+    "keyVaultName": {
+      "type": "string"
+    },
+    "enabledForTemplateDeployment": {
+      "type": "bool"
+    }
+  },
+  "variables": {
+    "tenantId": "[subscription().tenantId]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2021-10-01",
+      "name": "[parameters('keyVaultName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "enableSoftDelete": true,
+        "enabledForTemplateDeployment": "[parameters('enabledForTemplateDeployment')]",
+        "enableRbacAuthorization": true,
+        "enablePurgeProtection": true,
+        "tenantId": "[variables('tenantId')]",
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        }
+      }
+    }
+  ]
+}

--- a/azure/templates/storage-account.json
+++ b/azure/templates/storage-account.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string"
+    },
+    "sku": {
+        "type": "string",
+        "allowedValues": [
+          "Standard_GRS",
+          "Standard_ZRS"
+        ]
+    },
+    "storageAccountName": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2021-09-01",
+      "name": "[parameters('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "kind": "StorageV2",
+      "properties": {
+        "minimumTlsVersion": "TLS1_2",
+        "supportsHttpsTrafficOnly": true,
+        "allowBlobPublicAccess": false
+      },
+      "sku": {
+        "name": "[parameters('sku')]"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices",
+      "apiVersion": "2021-09-01",
+      "name": "[format('{0}/default', parameters('storageAccountName'))]",
+      "properties": {
+        "containerDeleteRetentionPolicy": {
+          "allowPermanentDelete": false,
+          "days": 30,
+          "enabled": true
+        },
+        "deleteRetentionPolicy": {
+          "allowPermanentDelete": false,
+          "days": 30,
+          "enabled": true
+        },
+        "isVersioningEnabled": true
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
+    }
+  ]
+}

--- a/azure/templates/storage-blob-container.json
+++ b/azure/templates/storage-blob-container.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountName": {
+      "type": "string"
+    },
+    "storageContainerName": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2021-09-01",
+      "name": "[format('{0}/default/{1}', parameters('storageAccountName'), parameters('storageContainerName'))]",
+      "properties": {
+        "publicAccess": "None"
+      }
+    }
+  ]
+}

--- a/azure/templates/storage-management-policy.json
+++ b/azure/templates/storage-management-policy.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountName": {
+      "type": "string"
+    },
+    "storageContainerName": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "name": "[concat(parameters('storageAccountName'), '/default')]",
+      "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+      "apiVersion": "2019-06-01",
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "ruleDelete",
+              "enabled": true,
+              "type": "Lifecycle",
+              "definition": {
+                "filters": {
+                  "blobTypes": ["blockBlob"],
+                  "prefixMatch": [
+                    "[parameters('storageContainerName')]"
+                  ]
+                },
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 35
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 35
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Context

The existing version uses deeply nested deployment templates that are hard to read and difficult to extend or improve.

## Changes in this PR

Refactor the template to use linked templates so that readability is improved.

## Testing

1. From a repo that uses resourcedeploy.json, eg [qualified-teachers-api](https://github.com/DFE-Digital/qualified-teachers-api/blob/8a08d3e082aa216917159213b96dbb35a655b287/Makefile#L152), run `make dev validate-azure-resources` and make a note of the output
2. Modify the `make` recipe so that it uses the template in this branch, remove the `"environment=${DEPLOY_ENV}"` parameter
3. In tra-shared-services modify the [deploymentUrlBase](https://github.com/DFE-Digital/tra-shared-services/blob/78ac15d08da78930373620624aeea2b032e0dd36/azure/resourcedeploy.json#L37) so that it references this branch rather than `main`, commit and push this change
4. Run the `make` recipe and compare the output to step 1, they should be the same