### PR TITLE
Pinned getanid terraform module to release v0.3.0

### DIFF
--- a/custom_domains/getanid/main.tf
+++ b/custom_domains/getanid/main.tf
@@ -1,5 +1,5 @@
 module "domains" {
-  source              = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains"
+  source              = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains?ref=v0.3.0"
   zone                = var.zone
   front_door_name     = var.front_door_name
   resource_group_name = var.resource_group_name


### PR DESCRIPTION
### Context

The custom_domains terraform for get-an-identity references the main branch of DFE-Digital/terraform-modules, this has since been updated and the terraform no longer runs.

### Changes proposed in this PR 

Pinned getanid to v0.3.0 of environment_domains module 

### Guidance to review

Run `make getanid dev domains-plan` & `make getanid production domains-plan` to confirm this results in no changes.