### PR TITLE
Destroy/remove AFQTS domain environment

### DIFF
--- a/custom_domains/afqts/workspace_variables/afqts_dev.tfvars.json
+++ b/custom_domains/afqts/workspace_variables/afqts_dev.tfvars.json
@@ -1,9 +1,0 @@
-{
-    "zone": "apply-for-qts-in-england.education.gov.uk",
-    "front_door_name": "s165p01-afqtsdomains-fd",
-    "resource_group_name": "s165p01-afqtsdomains-rg",
-    "domains": ["dev"],
-    "environment_short" : "dev",
-    "environment_tag" : "dev",
-    "origin_hostname": "apply-for-qts-in-england-dev.london.cloudapps.digital"
-}

--- a/custom_domains/afqts/workspace_variables/afqts_dev_backend.tfvars
+++ b/custom_domains/afqts/workspace_variables/afqts_dev_backend.tfvars
@@ -1,4 +1,0 @@
-resource_group_name  = "s165p01-afqtsdomains-rg"
-storage_account_name = "s165p01afqtsdomainstf"
-container_name       = "afqtsdomains-tf"
-key                  = "afqtsdomains_dev.tfstate"


### PR DESCRIPTION
The DEV configuration for DNS/Azure Front Door has been moved to the AFQTS repo.
Therefore the Dev terraform state for AFQTS has been destroyed in this repo.